### PR TITLE
[FIXED] This commit fix #4(update imports)

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -14,5 +14,4 @@
 #= require turbolinks
 #= require jquery
 #= require bootstrap
-#= require bootstrap-sprockets
 #= require_tree .


### PR DESCRIPTION
 - #4 に対応して, プルダウンメニューが正常に機能するように修正
   - 修正内容は, `app/assets/javascripts/application.js.coffee`でimportしていた`bootstrap-sprockets`の削除(これは, 最新のbootstrapでは必要なくなったらしい)